### PR TITLE
WIP: Try and speed up build system

### DIFF
--- a/build_lib
+++ b/build_lib
@@ -9,6 +9,7 @@ set -x
 BUILD_DIR=built_firmware
 workdir=$(pwd)
 params=($*)
+SYSTEM_CORES=$(cat /proc/cpuinfo | grep bogomips | wc -l)
 
 validate_architecture() {
   arch_requested=$1
@@ -86,8 +87,13 @@ openwrt_clone_and_patch() {
   echo "OpenWRT revision: ${openwrt_rev}"
   echo "Checking out OpenWRT into ${BUILD_DIR}, this could take some time"
 
-  rm -rf "${OPENWRT_CHECKOUT_DIR}"
-  git clone "git://git.openwrt.org/${openwrt_path}/openwrt.git" "${OPENWRT_CHECKOUT_DIR}"
+  if [ -d "$OPENWRT_CHECKOUT_DIR" ]; then 
+    cd "${OPENWRT_CHECKOUT_DIR}"
+    git clean -f
+  else
+    git clone "git://git.openwrt.org/${openwrt_path}/openwrt.git" "${OPENWRT_CHECKOUT_DIR}"
+  fi
+
   cd "${OPENWRT_CHECKOUT_DIR}"
   git checkout "${openwrt_rev}"
   cd "${workdir}"
@@ -188,10 +194,13 @@ openwrt_buildprep()
   local arch=$1
   local build_dir=${workdir}/${BUILD_DIR}/builder.${arch}
 
-  # Make hardlinks to avoid space duplication but to still isolate builds
-  cp -lr "${workdir}/${BUILD_DIR}/openwrt" "${build_dir}"
 
-  cp -r files "${build_dir}/"
+  if [ ! -d "$build_dir" ]; then 
+    # Make hardlinks to avoid space duplication but to still isolate builds
+    cp -lr "${workdir}/${BUILD_DIR}/openwrt" "${build_dir}"
+  fi
+
+  rsync --delete -a files "${build_dir}/"
 
   local toolchain_dir_bin
   for file in ${build_dir}/staging_dir/*; do
@@ -231,11 +240,17 @@ openwrt_buildprep()
 
 openwrt_builder()
 {
+  # Entierly arbitrary multiplier
+  BUILD_CORES=$(($SYSTEM_CORES * 2))
+  if [ -v $SUDOWRT_DEBUG ]; then
+    BUILD_CORES=1
+  fi
+
   local arch=$1
   local build_dir=${workdir}/${BUILD_DIR}/builder.${arch}
   mkdir -p ${build_dir}
   echo "Building [${arch}] in dir: ${build_dir}..."  
-  make V=s -C "${build_dir}" 2>&1 | tee -a "${build_dir}/build.log"
+  make -j$SYSTEM_CORES V=s -C "${build_dir}" 2>&1 | tee -a "${build_dir}/build.log"
   if [ "$?" != "0" ]; then
     echo "Building [${arch}] failed. See ${build_dir}/build.log for details!"
     exit 1


### PR DESCRIPTION
So there are two very basic features of make that this build system
seems to intentionally short circuit. 1) parallelism and
2) build caching. Some basic tests of my own show that paralleism
is a 6x build speed increase on my desktop and caching results
in a 3min rebuild after building everything once. The issue is
of course dealing with transforming an existing build directory
with cached build data into one with changes. Paralleism also
makes debugging difficult, so you have to either have a debugging
mode or tell the user 'go to this dir and run make V=s'.

I think this patch still has some bugs, it's difficult to test on
my Fedora machine (distro specific build systems and docker based
build systems generally solve problems today but create problems
of unknown deps and requirements in the future).